### PR TITLE
feat: better argparsing and various improvements

### DIFF
--- a/src/cmds/mjs/amae_api.ts
+++ b/src/cmds/mjs/amae_api.ts
@@ -11,7 +11,7 @@ import {
 import dayjs, { Dayjs } from "dayjs";
 import TTLCache from "@isaacs/ttlcache";
 
-const API_ROOT = "https://5-data.amae-koromo.com/api/v2/pl4";
+const API_ROOT = "https://4.data.amae-koromo.com/api/v2/pl4";
 
 // Cache with 5 minutes TTL
 const cache = new TTLCache({ max: 1000, ttl: 1000 * 60 * 10 });

--- a/src/cmds/mjs/charts.ts
+++ b/src/cmds/mjs/charts.ts
@@ -25,7 +25,7 @@ export const generatePieChartSvg = (data: number[], xOffset = 0): string => {
     .slice()
     .reverse()
     .map((slice: number, index: number) => {
-      const sliceAngle = slice * 360;
+      const sliceAngle = slice * 360 * 0.999; // random hack allow pie chart with only one sector to render correctly
       const x1 = centerX + radius * Math.cos((Math.PI / 180) * currentAngle);
       const y1 = centerY + radius * Math.sin((Math.PI / 180) * currentAngle);
       const x2 =

--- a/src/cmds/mjs/common.ts
+++ b/src/cmds/mjs/common.ts
@@ -172,6 +172,7 @@ export const formatPercent = (x: any) => {
 };
 
 export const formatFixed3 = (x: number) => x.toFixed(3);
+export const formatFixed2 = (x: number) => x.toFixed(2);
 export const formatFixed1 = (x: number) => x.toFixed(1);
 export const formatRound = (x: number) => Math.round(x).toString();
 export const formatIdentity = (x: number | string) => x.toString();

--- a/src/cmds/mjs/majsoul_user.ts
+++ b/src/cmds/mjs/majsoul_user.ts
@@ -13,6 +13,7 @@ import {
   Result,
 } from "./common";
 import { MAJOR_RANK, Rank } from "./rank";
+import { ThreadMemberFlagsBitField } from "discord.js";
 
 export class MajsoulUser {
   amaeId: string;
@@ -21,6 +22,7 @@ export class MajsoulUser {
   recentResults?: Result[];
   rank?: Rank;
   rankLastWeek?: Rank;
+  avgPlacement?: number;
   playerStats: { [modeStr: string]: PlayerStatsResponse } = {};
   extendedStats: { [modeStr: string]: PlayerExtendedStatsResponse } = {};
   constructor(amaeId: string) {
@@ -219,13 +221,25 @@ export class MajsoulUser {
    * @returns
    */
   async fetchLightStats() {
-    const playerStats = await getPlayerStats(
-      this.amaeId,
-      undefined,
-      undefined,
-      undefined
-    );
+    const startDate = dayjs().subtract(6, "months");
+    let playerStats: PlayerStatsResponse;
+    try {
+      playerStats = await getPlayerStats(
+        this.amaeId,
+        startDate,
+        undefined,
+        undefined
+      );
+    } catch {
+      playerStats = await getPlayerStats(
+        this.amaeId,
+        undefined,
+        undefined,
+        undefined
+      );
+    }
     this.mjsNickname = playerStats.nickname;
+    this.avgPlacement = playerStats.avg_rank;
     this.rank = new Rank(
       playerStats.level.id,
       playerStats.level.score,

--- a/src/cmds/wwyd.ts
+++ b/src/cmds/wwyd.ts
@@ -271,7 +271,7 @@ export const prepareWwydEmbed = async (
     ? wwyds[today.diff(START_DATE, "day")]
     : wwyds[Math.floor(Math.random() * wwyds.length)];
     
-  embed.setTitle(`Answer: ${spoiler(wwyd.answer)}`);
+  embed.setTitle(`Answer: \\| ${spoiler(wwyd.answer)} \\|`);
 
   const parseCommentElements = (str: string[] | string) => {
     if (!Array.isArray(str)) {


### PR DESCRIPTION
Changes
- Fix pie chart rendering incorrectly with 100% one value
- Add proper argument parsing using `node:util` `parseArgs`
  - For leaderboard, add sort and page options
  - Example: `ron mjs lb --sortby delta --page 2`
  - For stats, add limit option (how many recent games to include in stats
  - Example: `ron mjs stats --limit 300`
- Add more stats (dama rate, uradora rate, average placement)
- Add average rank to leaderboard
- make the WWYD answer more clear on mobile
- Lil bit of refactoring